### PR TITLE
Use consistent variable names

### DIFF
--- a/doc/crypto/X509_NAME_get_index_by_NID.pod
+++ b/doc/crypto/X509_NAME_get_index_by_NID.pod
@@ -83,10 +83,9 @@ Process all entries:
 
 Process all commonName entries:
 
- int loc;
+ int lastpos = 1;
  X509_NAME_ENTRY *e;
 
- loc = -1;
  for (;;)
         {
         lastpos = X509_NAME_get_index_by_NID(nm, NID_commonName, lastpos);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated

##### Description of change
<!-- Provide a description of the changes.

If it fixes a github issue, add Fixes #XXXX.
-->

In the X509_NAME_get_index_by_NID.pod example, the initialized variable is
called "loc", but the one used in the for loop is called "lastpos". Make the names
match.

I submit this as a separate pull request because the directory structure has changed from master to
this branch. This commit can be cherry-picked into the other stable branches.